### PR TITLE
tackler: Use flat balance for tests

### DIFF
--- a/100k/tackler.toml
+++ b/100k/tackler.toml
@@ -25,8 +25,8 @@ report-timezone = "UTC"
 scale = { min = 2, max = 7 }
 accounts = [ ]
 targets  = [ "balance" ]
-balance  = { title = "Balance Report" }
-balance-group = { title = "Balance Group Report", group-by = "month" }
+balance  = { title = "Balance Report", type = "flat" }
+balance-group = { title = "Balance Group Report", type = "flat", group-by = "month" }
 register      = { title = "Register Report", accounts = [  ]}
 
 [export]

--- a/10k/tackler.toml
+++ b/10k/tackler.toml
@@ -25,8 +25,8 @@ report-timezone = "UTC"
 scale = { min = 2, max = 7 }
 accounts = [ ]
 targets  = [ "balance" ]
-balance  = { title = "Balance Report" }
-balance-group = { title = "Balance Group Report", group-by = "month" }
+balance  = { title = "Balance Report", type = "flat" }
+balance-group = { title = "Balance Group Report", type = "flat", group-by = "month" }
 register      = { title = "Register Report", accounts = [  ]}
 
 [export]

--- a/500k/tackler.toml
+++ b/500k/tackler.toml
@@ -25,8 +25,8 @@ report-timezone = "UTC"
 scale = { min = 2, max = 7 }
 accounts = [ ]
 targets  = [ "balance" ]
-balance  = { title = "Balance Report" }
-balance-group = { title = "Balance Group Report", group-by = "month" }
+balance  = { title = "Balance Report", type = "flat" }
+balance-group = { title = "Balance Group Report", type = "flat", group-by = "month" }
 register      = { title = "Register Report", accounts = [  ]}
 
 [export]


### PR DESCRIPTION
The flat balance reporting mode needs tackler version 25.04.2 or newer.

You can update tackler just by running:

````
cargo install --locked tackler
````

Cargo will keep track of installed versions, and it will skip the installation in case it's not needed. 