### PR TITLE
Add generic benchmark setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ currently Ledger, hledger, Beancount, and Tackler.
 - 10k - balance report with 10 thousand transactions and 1 thousand accounts
 - 100k - balance report with 100 thousand transactions and 1 thousand accounts
 - 500k - balance report with 500 thousand transactions and 1 thousand accounts
+- generic - benchmark (time, mem, cpu) of balance report with different journal sizes
 
 Tools that may be useful:
 
 - just       - https://just.systems
 - quickbench - https://hackage.haskell.org/package/quickbench
+- pta-generator     - https://github.com/tackler-ng/pta-generator
 - BSD time or GNU time
 
 - ledger     - https://ledger-cli.org

--- a/generic/.gitignore
+++ b/generic/.gitignore
@@ -1,0 +1,1 @@
+/bench_data/

--- a/generic/README.md
+++ b/generic/README.md
@@ -1,0 +1,57 @@
+# Generic Performance Benchmarks
+
+This directory contains generic benchmark setup
+with generated plain text accounting data.
+
+Benchmark results will report used time, memory and CPU utilization for
+basic balance report with commodities.
+
+Generated transaction set contains roughly 400 accounts and 31 commodities.
+
+Test setup supports various test set sizes, ranging from 10 (1e1)
+to 1_000_000 (1e6) transactions.
+
+Reasonable starting point would be 10_000 (1e4) transactions.
+
+
+## Installation
+
+Install the [PTA-Generator](https://github.com/tackler-ng/pta-generator):
+
+````
+cargo install --locked pta-generator
+````
+
+You also need to have [just](https://just.systems/) installed,
+and the PTA tools.
+
+### Installation of PTA Tools
+
+Currently tested tools are beancount, hledger, ledger and tackler.
+
+Installation instructions for these are located here:
+
+* Beancount: [Installing Beancount](https://beancount.github.io/docs/installing_beancount.html)
+* HLedger: [Install](https://hledger.org/install.html)
+* Ledger: [Download](https://ledger-cli.org/download.html)
+* Tackler: [Quickstart](https://tackler.e257.fi/docs/quickstart/)
+
+
+## Usage
+
+After that the usage is super-simple, just run:
+
+````bash
+just help
+just gen 1e4
+just bench 1e4
+just version
+````
+
+The set size could be `1e1`, `1e2`, ..., `1e5`, `1e6`.
+
+PTA tools are run in order of probable execution time (fastest first).
+
+If the `time` command in the justfile doesn't work for you, then just use
+the the other version of `time` in the script.
+

--- a/generic/justfile
+++ b/generic/justfile
@@ -1,0 +1,72 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4 smarttab expandtab autoindent
+#
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025 35V LG84 <https://github.com/35vlg84>
+
+set positional-arguments
+
+alias gen  := generate
+alias help := default
+
+data_path := "bench_data"
+
+ptag := "pta-generator"
+tackler := 'tackler'
+ledger := 'ledger'
+hledger := 'hledger'
+bean-query := 'bean-query'
+
+#time_var := 'time -f "$tool: \tReal\t%e s;\tMem \t%M Kbytes;\tCPU\t%P"'
+time_var := 'gtime -f "$tool: \tReal\t%e s;\tMem \t%M Kbytes;\tCPU\t%P"'
+
+# List all targets and used data_path
+default:
+    @just --list --unsorted
+    @echo "Used {{{{data_path}} is: {{data_path}}"
+
+# Clean all data under '{{data_path}}/comm'
+clean-data:
+    rm -rf "{{data_path}}/comm"
+
+# Generate data set, SET_SIZE could be: 1e1, 1e2, ..., 1e6
+generate SET_SIZE:
+    @echo "### Generating test data for 'comm', size: {{SET_SIZE}}"
+    @{{ptag}} comm --path "{{data_path}}" --set-size {{SET_SIZE}} --shard-type single --flavor tackler > /dev/null
+    @{{ptag}} comm --path "{{data_path}}" --set-size {{SET_SIZE}} --shard-type single --flavor ledger > /dev/null
+    @{{ptag}} comm --path "{{data_path}}" --set-size {{SET_SIZE}} --shard-type single --flavor beancount > /dev/null
+    @echo "### Done"
+
+# Run benchmark with generated data, SET_SIZE could be: 1e1, 1e2, ..., 1e6
+bench SET_SIZE:
+    @if [[ ! -e "{{data_path}}/comm/set-{{SET_SIZE}}-single.toml" ]]; then echo "Please generate first data set: {{SET_SIZE}}"; exit 1; fi
+    @echo "###"
+    @echo "### Journal with Commodities, {{SET_SIZE}} txns"
+    @echo "###"
+    tool={{tackler}}; {{time_var}} \
+        {{tackler}} --config "{{data_path}}/comm/set-{{SET_SIZE}}-single.toml" > /dev/null
+    @echo
+
+    tool={{ledger}}; {{time_var}} \
+        {{ledger}}        -f "{{data_path}}/comm/set-{{SET_SIZE}}-single/txns/{{SET_SIZE}}.journal" bal >/dev/null
+    @echo
+
+    tool={{hledger}}; {{time_var}} \
+        {{hledger}}       -f "{{data_path}}/comm/set-{{SET_SIZE}}-single/txns/{{SET_SIZE}}.journal" bal >/dev/null
+    @echo
+
+    tool={{bean-query}}; {{time_var}} \
+        {{bean-query}}       "{{data_path}}/comm/set-{{SET_SIZE}}-single/txns/{{SET_SIZE}}.beancount"  'balances from year = 2024' >/dev/null
+    @echo
+
+# Report PTA tool versions
+version:
+    @{{ptag}} --version
+    @{{tackler}} --version
+    @{{ledger}} --version | head -n1
+    @{{hledger}} --version
+    @{{bean-query}} --version
+
+# Install PTA-Generator tool
+install:
+    cargo install --locked pta-generator
+


### PR DESCRIPTION
This uses on-the-fly generated PTA test data, and it generates valid test data for ledger, hledger, beancount and tackler.

It benchmarks used time, memory and CPU utilization.